### PR TITLE
 Add Optional Dependencies Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 
 D3 Shape is a set of primitives for building complex data visualisations. Because
 it depends on all the other components of D3, this package also provides all other
-D3 `v4.0` packages (see below for a list). 
+D3 `v4.0` packages (see below for a list).
 
 This addon is just a shim, if you're looking for a more high level visualisation addon,
 check out [maximum-plaid](https://github.com/ivanvanderbyl/maximum-plaid).
 
-Each package is importable as per the D3 documentation for each package. 
+Each package is importable as per the D3 documentation for each package.
 This also means that you don't need to import the entire `d3.js` build into your App if you
 only need a function or two. For example, check out [d3-array](https://github.com/d3/d3-array) for
 an extensive library of useful Array functions not natively found in Javascript.
@@ -57,8 +57,8 @@ import { extent } from 'd3-array';
 - [d3-voronoi](https://github.com/d3/d3-voronoi)
 - [d3-zoom](https://github.com/d3/d3-zoom)
 
-_This addon will be updated when new releases are cut of these packages. 
-Currently none of these are 1.0 stable, so some of your code might break by 
+_This addon will be updated when new releases are cut of these packages.
+Currently none of these are 1.0 stable, so some of your code might break by
 upgrading. It is recommended that you have solid tests in place._
 
 ## Installation & Usage
@@ -86,6 +86,27 @@ export default Ember.Component.extend({
   }
 });
 ```
+
+## Svelte Builds
+
+In case you do not want to include *all* of d3's dependencies, you may whitelist the packages
+that you want to include in your project's `config/environment.js` file.
+
+For example, if you only wanted to use `d3-scale`, you would do:
+
+```js
+// config/environment.js
+module.exports = function() {
+  return {
+    'ember-cli-d3-shape': {
+      only: ['d3-scale']
+    }
+  };
+};
+```
+
+**Note**: Even though you only add `d3-scale`, it has a few transitive d3 dependencies.
+These are added to your project automatically.
 
 ## Running
 

--- a/lib/d3-deps-for-package.js
+++ b/lib/d3-deps-for-package.js
@@ -1,0 +1,8 @@
+var path = require('path');
+var lookupPackage = require('./lookup-package-build');
+var isD3Dependency = require('./is-d3-dependency');
+
+module.exports = function(packageName) {
+  var pkg = require(path.join(lookupPackage(packageName), 'package.json'));
+  return Object.keys(pkg.dependencies).filter(isD3Dependency);
+}

--- a/lib/is-d3-dependency.js
+++ b/lib/is-d3-dependency.js
@@ -1,0 +1,3 @@
+module.exports = function(name) {
+  return /^d3\-/.test(name);
+}

--- a/lib/lookup-package-build.js
+++ b/lib/lookup-package-build.js
@@ -1,0 +1,7 @@
+var path = require('path');
+
+module.exports = function lookupPackage(packageName) {
+  var modulePath = require.resolve(packageName);
+  var i = modulePath.lastIndexOf(path.sep + 'build');
+  return modulePath.slice(0, i);
+}

--- a/lib/path-to-d3-module-src.js
+++ b/lib/path-to-d3-module-src.js
@@ -1,0 +1,32 @@
+var fs = require('fs');
+var path = require('path');
+var lookupPackage = lookupPackage = require('./lookup-package-build');
+var d3PackagePath = lookupPackage('d3');
+
+module.exports = function(packageName) {
+  var d3PathToSrc;
+
+  // Import existing builds from node d3 packages, which are UMD packaged.
+  var packageBuildPath = path.join('build', packageName + '.js');
+
+  d3PathToSrc = path.join(d3PackagePath, 'node_modules', packageName);
+
+  try {
+    fs.statSync(path.join(d3PathToSrc)).isDirectory();
+  } catch(err) {
+    d3PathToSrc = lookupPackage(packageName);
+  }
+
+  try {
+    fs.statSync(path.join(d3PathToSrc, packageBuildPath)).isFile()
+  } catch(err) {
+    console.error('[ERROR] D3 Package (' + packageName + ') is not built as expected, cannot continue. Please report this as a bug.');
+    return;
+  }
+
+  return {
+    packageBuildPath: packageBuildPath,
+    d3PathToSrc: d3PathToSrc,
+    packageName: packageName
+  };
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "test": "ember try:each"
+    "test": "ember try:each",
+    "node-test": "mocha test --recursive --reporter spec"
   },
   "repository": "ivanvanderbyl/ember-cli-d3-shape",
   "engines": {
@@ -19,6 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
+    "chai": "^3.5.0",
     "ember-ajax": "2.3.1",
     "ember-cli": "2.6.2",
     "ember-cli-app-version": "^1.0.0",
@@ -37,6 +39,7 @@
     "ember-resolver": "^2.0.3",
     "ember-suave": "2.0.1",
     "loader.js": "^4.0.1",
+    "mocha": "^3.0.2",
     "npm-registry-client": "^7.1.1",
     "semver": "^5.1.0"
   },

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,0 +1,27 @@
+/* globals describe, it */
+'use strict';
+
+var addonIndex = require('../index');
+var expect = require('chai').expect;
+var d3DepsForPackage = require('../lib/d3-deps-for-package');
+
+describe('index', function() {
+  it('exists', function() {
+    expect(addonIndex).to.exist;
+  });
+
+  it('returns all d3 dependencies if only is not provided', function() {
+    var modules = addonIndex.getD3Modules({});
+    expect(modules).to.not.be.empty;
+  });
+
+  it('returns all d3 dependencies if only is empty', function() {
+    var modules = addonIndex.getD3Modules({ only: [] });
+    expect(modules).to.not.be.empty;
+  });
+
+  it('returns select d3 dependencies if only option provided', function() {
+    var modules = addonIndex.getD3Modules({ only: ['d3-shape'] });
+    expect(modules.length).to.equal(d3DepsForPackage('d3-shape').length + 1);
+  });
+});


### PR DESCRIPTION
This PR adds support to define an `only` configuration which would make the consuming app only need to import only the required dependencies, rather than every d3 dependency. 

I've also added a small handful of tests for the `index.js` file (`npm run node-test`). Test coverage isn't great for everything going on in there — but this is at least a start. 
